### PR TITLE
Concurrency

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -20,8 +20,7 @@ func NewAgent(directives *Directive) Agent {
 
 	deadNode := make(chan bool)
 	for i := 0; i < directives.Workers; i++ {
-		w := NewWorker(directives, &rpc_config, deadNode)
-		w.run()
+		NewWorker(directives, &rpc_config, deadNode)
 	}
 	return Agent{
 		Directives: directives,
@@ -33,7 +32,6 @@ func NewAgent(directives *Directive) Agent {
 func (a *Agent) run() {
 	for {
 		_ = <-a.DeadNode
-		w := NewWorker(a.Directives, a.RPCConfig, a.DeadNode)
-		w.run()
+		NewWorker(a.Directives, a.RPCConfig, a.DeadNode)
 	}
 }

--- a/agent.go
+++ b/agent.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	rpc "github.com/hashicorp/serf/client"
+)
+
+type Agent struct {
+	Directives *Directive
+	RPCConfig  *rpc.Config
+	DeadNode   chan bool
+}
+
+func NewAgent(directives *Directive) Agent {
+	// create RPC config
+	rpc_config := rpc.Config{
+		Addr:    directives.Rpc_addr,
+		AuthKey: directives.Rpc_auth,
+		Timeout: directives.Rpc_timeout,
+	}
+
+	deadNode := make(chan bool)
+	for i := 0; i < directives.Workers; i++ {
+		w := NewWorker(directives, &rpc_config, deadNode)
+		w.run()
+	}
+	return Agent{
+		Directives: directives,
+		RPCConfig:  &rpc_config,
+		DeadNode:   deadNode,
+	}
+}
+
+func (a *Agent) run() {
+	for {
+		_ = <-a.DeadNode
+		w := NewWorker(a.Directives, a.RPCConfig, a.DeadNode)
+		w.run()
+	}
+}

--- a/directive.go
+++ b/directive.go
@@ -21,6 +21,7 @@ type Directive struct {
 	Rpc_addr    string        `json:"rpc-addr"`
 	Rpc_auth    string        `json:"rpc-auth"`
 	Rpc_timeout time.Duration `json:"rpc-timeout"`
+	Workers     int           `json:"rpc-workers"`
 	Templates   []Template
 }
 
@@ -33,6 +34,10 @@ func ParseDirectives(config_file string) (Directive, error) {
 	err = json.Unmarshal(config_json, &directive)
 	if err != nil {
 		panic(err)
+	}
+	// default RPC workers
+	if directive.Workers == 0 {
+		directive.Workers = 1
 	}
 	// default RPC address
 	if directive.Rpc_addr == "" {

--- a/directive.go
+++ b/directive.go
@@ -25,15 +25,15 @@ type Directive struct {
 	Templates   []Template
 }
 
-func ParseDirectives(config_file string) (Directive, error) {
+func ParseDirectives(config_file string) (*Directive, error) {
 	config_json, err := ioutil.ReadFile(config_file)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	var directive Directive
 	err = json.Unmarshal(config_json, &directive)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	// default RPC workers
 	if directive.Workers == 0 {
@@ -45,5 +45,5 @@ func ParseDirectives(config_file string) (Directive, error) {
 	}
 	// timeout in millisecond. time.Duration use nanosecond by default
 	directive.Rpc_timeout = directive.Rpc_timeout * 1000000
-	return directive, nil
+	return &directive, nil
 }

--- a/directive_test.go
+++ b/directive_test.go
@@ -1,21 +1,39 @@
 package main
 
 import (
-	//"testing"
+	"os"
 	"fmt"
 )
 
 func ExampleParseDirectives() {
-	var d Directive
+	var d *Directive
 	var e error
-	// example 1: no config
+	// example 1: bad path
+	d, e = ParseDirectives("test/unknown.json")
+	if e == nil || d != nil {
+		panic(e)
+	}
+
+	// example 2: bad json
+	if _, e = os.Create("test/empty"); e != nil {
+		panic(e)
+	}
+	d, e = ParseDirectives("test/empty")
+	if e == nil || d != nil {
+		panic(e)
+	}
+	if e = os.Remove("test/empty"); e != nil {
+		panic(e)
+	}
+
+	// example 3: no config
 	d, e = ParseDirectives("test/config_1.json")
 	if e != nil {
 		panic(e)
 	}
-	fmt.Println(d)
+	fmt.Println(*d)
 
-	// example 2: full config
+	// example 4: full config
 	d, e = ParseDirectives("test/config_2.json")
 	if e != nil {
 		panic(e)

--- a/directive_test.go
+++ b/directive_test.go
@@ -30,11 +30,12 @@ func ExampleParseDirectives() {
 	fmt.Println(d.Rpc_addr)
 	fmt.Println(d.Rpc_auth)
 	fmt.Println(d.Rpc_timeout)
+	fmt.Println(d.Workers)
 	fmt.Println(d.Templates[0].Src)
 	fmt.Println(d.Templates[0].Dest)
 	fmt.Println(d.Templates[0].Cmd)
 	// Output:
-	// {    map[] 127.0.0.1:7373  0 []}
+	// {    map[] 127.0.0.1:7373  0 1 []}
 	// serf
 	// svr
 	// web
@@ -45,6 +46,7 @@ func ExampleParseDirectives() {
 	// 127.0.0.1:7373
 	// rpcauthtoken
 	// 500ms
+	// 5
 	// /path/to/template.tpl
 	// /path/to/result.file
 	// service dummy restart

--- a/directive_test.go
+++ b/directive_test.go
@@ -49,5 +49,5 @@ func ExampleParseDirectives() {
 	// 5
 	// /path/to/template.tpl
 	// /path/to/result.file
-	// service dummy restart
+	// ls
 }

--- a/main.go
+++ b/main.go
@@ -2,38 +2,42 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"log"
-	"fmt"
 	"os"
 )
 
 const (
-	DEBUG      = true
-	DEBUG_FILE = "/tmp/serf_template.log"
+	DEBUG       = false
+	DEBUG_FILE  = "/var/log/serf_template.log"
+	CONFIG_FILE = "/etc/serf_template/config.json"
 )
 
 func main() {
-	fmt.Println("starting")
-	// if DEBUG {
-	// 	log_file, _ := os.Create(DEBUG_FILE)
-	// 	defer log_file.Close()
-	// 	log.SetOutput(log_file)
-	// 	log.Println("Serf Template starting")
-	// }
+	debug := flag.Bool("debug", DEBUG, "enable debug")
+	debugFile := flag.String("log", DEBUG_FILE, "log file for debuging")
+	configFile := flag.String("config", CONFIG_FILE, "path to the config file")
+	flag.Parse()
 
-	if len(os.Args) != 2 {
+	if *debug {
+		log_file, _ := os.Create(*debugFile)
+		defer log_file.Close()
+		log.SetOutput(log_file)
+		log.Println("Serf Template starting")
+	}
+
+	if *configFile == "" {
 		err := errors.New("No config file")
 		panic(err)
 	}
 
 	// parse directive from config file
-	directives, err := ParseDirectives(os.Args[1])
+	directives, err := ParseDirectives(*configFile)
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("parsed directives: %v\n", directives)
-	if DEBUG {
+	if *debug {
 		log.Printf("directives: %v", directives)
 	}
 

--- a/main.go
+++ b/main.go
@@ -38,10 +38,10 @@ func main() {
 	}
 
 	if *debug {
-		log.Printf("directives: %v", directives)
+		log.Printf("directives: %v", *directives)
 	}
 
-	agent := NewAgent(&directives)
+	agent := NewAgent(directives)
 
 	agent.run()
 }

--- a/main.go
+++ b/main.go
@@ -1,40 +1,25 @@
 package main
 
 import (
-	//"encoding/json"
 	"errors"
-	//"fmt"
-	"os"
-	"os/exec"
-	//"strconv"
-	rpc "github.com/hashicorp/serf/client"
 	"log"
-	"strings"
-	//"text/template"
+	"fmt"
+	"os"
 )
 
-// exit codes
-/*
 const (
-	OK                    = iota
-	SYNTAX_ERROR          = iota
-	CMD_FAILED            = iota
-	TEMPLATE_PARSE_FAILED = iota
-)
-*/
-
-const (
-	DEBUG      = false
+	DEBUG      = true
 	DEBUG_FILE = "/tmp/serf_template.log"
 )
 
 func main() {
-	if DEBUG {
-		log_file, _ := os.Create(DEBUG_FILE)
-		defer log_file.Close()
-		log.SetOutput(log_file)
-		log.Println("Serf Template starting")
-	}
+	fmt.Println("starting")
+	// if DEBUG {
+	// 	log_file, _ := os.Create(DEBUG_FILE)
+	// 	defer log_file.Close()
+	// 	log.SetOutput(log_file)
+	// 	log.Println("Serf Template starting")
+	// }
 
 	if len(os.Args) != 2 {
 		err := errors.New("No config file")
@@ -47,54 +32,12 @@ func main() {
 		panic(err)
 	}
 
+	fmt.Printf("parsed directives: %v\n", directives)
 	if DEBUG {
-		log.Printf("directives: %s", directives)
+		log.Printf("directives: %v", directives)
 	}
 
-	// create RPC config
-	rpc_config := rpc.Config{
-		Addr:    directives.Rpc_addr,
-		AuthKey: directives.Rpc_auth,
-		Timeout: directives.Rpc_timeout,
-	}
-	// create connection to the RPC interface
-	rpc_client, err := rpc.ClientFromConfig(&rpc_config)
-	if err != nil {
-		panic(err)
-	}
-	defer rpc_client.Close()
+	agent := NewAgent(&directives)
 
-	// create input channel
-	ch := make(chan map[string]interface{})
-	_, err = rpc_client.Stream("member-join,member-failed,member-update,member-leave,member-reap", ch)
-	if err != nil {
-		panic(err)
-	}
-
-	for {
-		// wait for signal from serf
-		<-ch
-
-		// get members' information
-		members, err := rpc_client.MembersFiltered(directives.Tags, directives.Status, directives.Name)
-		if err != nil {
-			panic(err)
-		}
-
-		// for each templates:
-		// - render template
-		// - execute command if any
-		for i := 0; i < len(directives.Templates); i++ {
-			RenderTemplate(directives.Templates[i].Src, directives.Templates[i].Dest, members)
-
-			if directives.Templates[i].Cmd != "" {
-				cmd_args := strings.Split(directives.Templates[i].Cmd, " ")
-				cmd := exec.Command(cmd_args[0], cmd_args[1:]...)
-				err := cmd.Run()
-				if err != nil {
-					panic(err)
-				}
-			}
-		}
-	}
+	agent.run()
 }

--- a/test/config_2.json
+++ b/test/config_2.json
@@ -15,7 +15,7 @@
 	{
 		"src": "/path/to/template.tpl",
 		"dest": "/path/to/result.file",
-		"cmd": "service dummy restart"
+		"cmd": "ls"
 	}
 	]
 }

--- a/test/config_2.json
+++ b/test/config_2.json
@@ -10,6 +10,7 @@
 	"rpc-addr": "127.0.0.1:7373",
 	"rpc-auth": "rpcauthtoken",
 	"rpc-timeout": 500,
+	"rpc-workers": 5,
 	"templates": [
 	{
 		"src": "/path/to/template.tpl",

--- a/worker.go
+++ b/worker.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	rpc "github.com/hashicorp/serf/client"
+	"os/exec"
+	"strings"
+)
+
+type Worker struct {
+	Directives *Directive
+	Client     *rpc.RPCClient
+	DeadNode   chan bool
+}
+
+func NewWorker(config *Directive, rpc_config *rpc.Config, deadNode chan bool) *Worker {
+	// create connection to the RPC interface
+	rpc_client, err := rpc.ClientFromConfig(rpc_config)
+	if err != nil {
+		panic(err)
+	}
+
+	return &Worker{
+		Directives: config,
+		Client:     rpc_client,
+		DeadNode:   deadNode,
+	}
+}
+
+func (w *Worker) run() {
+	defer func() {
+		w.Client.Close()
+		w.DeadNode <- true
+	}()
+
+	ch := make(chan map[string]interface{})
+	suscription, err := w.Client.Stream("member-join,member-failed,member-update,member-leave,member-reap", ch)
+	if err != nil {
+		panic(err)
+	}
+	defer w.Client.Stop(suscription)
+
+	for {
+		// wait for signal from serf
+		<-ch
+
+		if err = w.processTemplates(); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func (w *Worker) processTemplates() error {
+	members, err := w.Client.MembersFiltered(w.Directives.Tags, w.Directives.Status, w.Directives.Name)
+	if err != nil {
+		return err
+	}
+
+	// for each templates:
+	// - render template
+	// - execute command if any
+	for i := 0; i < len(w.Directives.Templates); i++ {
+		RenderTemplate(w.Directives.Templates[i].Src, w.Directives.Templates[i].Dest, members)
+
+		if w.Directives.Templates[i].Cmd != "" {
+			err = w.runCmd(w.Directives.Templates[i].Cmd)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (w *Worker) runCmd(cmdString string) error {
+	cmd_args := strings.Split(cmdString, " ")
+	cmd := exec.Command(cmd_args[0], cmd_args[1:]...)
+	return cmd.Run()
+}

--- a/worker.go
+++ b/worker.go
@@ -19,11 +19,14 @@ func NewWorker(config *Directive, rpc_config *rpc.Config, deadNode chan bool) *W
 		panic(err)
 	}
 
-	return &Worker{
+	w := Worker{
 		Directives: config,
 		Client:     rpc_client,
 		DeadNode:   deadNode,
 	}
+	go w.run()
+
+	return &w
 }
 
 func (w *Worker) run() {


### PR DESCRIPTION
Create several workers and delegate the work to them

Notice this is a WIP, do not merge yet

_FEATURES_
- Configurable number of workers
- The adapter keeps the number of workers
- One client connection per worker
- Cancel suscription and close the connection when a worker dies

_TODO_
- create a template object per template file and reuse them
- write templates on temporal files and move them after updating, so changes are atomic
